### PR TITLE
Add link to Go implementation of SWHID

### DIFF
--- a/data/implementations.yaml
+++ b/data/implementations.yaml
@@ -99,3 +99,18 @@ implementations:
       - path
       - lines
       - bytes
+
+  - name: "go-swhid"
+    repository: "https://github.com/afbjorklund/go-swhid"
+    language: "Go"
+    maintainer: "Anders F Björklund"
+    description: "Go implementation of the SWHID standard"
+    license: "Apache-2.0"
+    license_url: "https://github.com/afbjorklund/go-swhid/blob/main/LICENSE"
+    types:
+      - cnt
+      - dir
+      - rev
+      - rel
+      - snp
+    qualifiers:

--- a/data/implementations.yaml
+++ b/data/implementations.yaml
@@ -114,3 +114,9 @@ implementations:
       - rel
       - snp
     qualifiers:
+      - origin
+      - visit
+      - anchor
+      - path
+      - lines
+      - bytes


### PR DESCRIPTION
I have not completed all tests, or added qualifiers to it yet.

https://github.com/afbjorklund/go-swhid

But it has basic object support, and support for git objects.

And also a novel feature of `-w` (write), like `git hash-object`